### PR TITLE
Added 1P Game structure to the main menu.

### DIFF
--- a/back/server/server.js
+++ b/back/server/server.js
@@ -5,7 +5,7 @@ Description: The program that initializes and manages the server that facilitate
 Inputs: None
 Outputs: None
 Sources: node.js, sockets.io, and express official documentation
-Authors: William Johnson, MAtthew Petillo
+Authors: William Johnson, Matthew Petillo
 Creation date: 9-10-24
 */
 
@@ -38,6 +38,9 @@ let playerSockets = {};
 let socketClientAssociations = {};
 
 let activeParties = {};
+
+// These are variables and functions that store the necessary structure needed for the server to implement the AI for a single player game.
+
 
 // Function that cleans up global associations for players to allow them to join new rounds/parties. Also cleans up a party.
 function cleanUpRound(players){
@@ -86,6 +89,12 @@ io.on('connection', (socket) => {
     console.log("Client Connected:", socket.id);
 
     socket.emit('getClientId', {});
+
+    // Placeholder for future AI implementation
+    socket.on('initiateSinglePlayer', (numShips) => {
+        // this console log is a placeholder for the future AI implementation
+        console.log('Single Player Game Initiated');
+    });
 
     socket.on('registerClientId', (data) => {
         playerSockets[data.ClientId] = socket;

--- a/front/Grid Test/script.js
+++ b/front/Grid Test/script.js
@@ -2,7 +2,7 @@
 Description: Grid creation, placing ships, game logic
 Inputs: 
 Outputs: Handles Front-End Game Logic and Game page
-Sources: stackoverflow.com (refresh how to using javascript and handling containers)
+Sources: stackoverflow.com (refresh how to use javascript and handling containers)
 Authors: Chase Curtis, William Johnson, Matthew Petillo, Emily Tso
 Creation date: 9-9-24
 */
@@ -314,7 +314,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     filledships[name] = positions;
                 }
             }
-            window.socket.emit("registerShipPlacements", filledships); //emmit ship placemnets to server
+            window.socket.emit("registerShipPlacements", filledships); //emit ship placements to server
         });
 
 

--- a/front/homeScreen/homeScreen.html
+++ b/front/homeScreen/homeScreen.html
@@ -25,12 +25,30 @@ Creation date: 9-10-24
 
     <!--Create buttons for player to start or join a game which activates that respective function-->
     <div id ="buttons" style="width: 300px; margin: auto; display:none;">
-      <button id="newGameButton">New Game</body>
-      <button id="joinGameButton">Join Game</button>
+        <button id="1PGameButton">Start 1 Player Game</button>
+        <button id="2PGameButton">Start 2 Player Game</button>
+      <button id="joinGameButton">Join 2 Player Game</button>
     </div>
+</body>
 
-    <!--Forms to get the player's input of number of ships to play with if hosting a new game or join code if joining a game-->
-    <form id="newGame" style="display:none" ><!--Player is creating game and will redirect to game once number of ships is selected using radio buttons-->
+    <!--Forms to get the player's input of number of ships to play with if playing single player, hosting a 2-player game, and join code if joining a game-->
+    <form id="new1PGame" style="display:none">
+        <p>Number of Ships</p>
+        <div class="ship_select1P" style="width: 300px; margin: 0 auto; ">
+            <input type="radio" id="1P1" name="ship_select1P" value="1" required>
+            <label for="1P1">1</label><br>
+            <input type="radio" id="2P1" name="ship_select1P" value="2" required>
+            <label for="2P1">2</label><br>
+            <input type="radio" id="3P1" name="ship_select1P" value="3" required>
+            <label for="3P1">3</label><br>
+            <input type="radio" id="4P1" name="ship_select1P" value="4" required>
+            <label for="4P1">4</label><br>
+            <input type="radio" id="5P1" name="ship_select1P" value="5" required checked> <!--Default value. Mostly to see the difference between P1 and P2 button selections-->
+            <label for="5P1">5</label><br>
+            <input id="start1PGameButton" type="button" value="Play">
+        </div>
+    </form>
+    <form id="new2PGame" style="display:none" ><!--Player is creating game and will redirect to game once number of ships is selected using radio buttons-->
         <p>Number of Ships</p>
         <div class="ship_select" style="width: 300px; margin: 0 auto; "> <!--Unites radio buttons to match style and same class-->
           <input type="radio" id="1" name="ship_select" value="1" required>
@@ -50,7 +68,7 @@ Creation date: 9-10-24
     <!--Player is joining Game and will redirect to game once code is entered-->
     <div id="joinGame" style = "display:none; text-align: center;"> 
         <p>Join Code</p>
-        <input id="joinCodeField" type="text" id ="enterCode" name = "enterCode" required>
+        <input id="joinCodeField" type="text" name="enterCode" required>
         <input id="joinPartyButton" type="submit" value="Play" style="width: 300px; margin: 0 auto;">
     </div>
 
@@ -69,7 +87,7 @@ Creation date: 9-10-24
 
     <!--Only shows for Host to begin game with opponent connected-->
     <div id ="startButton" style="width: 300px; margin: auto; display:none; text-align:center;">
-      <button id="startGameButton">Start Game!</body>
+      <button id="startGameButton">Start Game!</button>
     </div>
 
     <!--Shows while game is beginning-->
@@ -93,7 +111,8 @@ Creation date: 9-10-24
   
           waitForSocket(() => {
             //Creating needed html elements to communicate between the server and users
-            const newGameArea = document.getElementById("newGame");
+            const new1PGameArea = document.getElementById("new1PGame");
+            const new2PGameArea = document.getElementById("new2PGame");
             const joinGameArea = document.getElementById("joinGame");
             const partyCodeArea = document.getElementById("displayPartyCode");
             const buttonsArea = document.getElementById("buttons");
@@ -101,9 +120,11 @@ Creation date: 9-10-24
             const waitingArea = document.getElementById("waitingForHost");
             const startGameArea = document.getElementById("startButton");
 
-            const newGameButton = document.getElementById("newGameButton");
+            const onePGameButton = document.getElementById("1PGameButton");
+            const twoPGameButton = document.getElementById("2PGameButton");
             const joinGameButton = document.getElementById("joinGameButton");
             const createPartyButton = document.getElementById("createPartyButton");
+            const start1PGameButton = document.getElementById("start1PGameButton");
             const joinPartyButton = document.getElementById("joinPartyButton");
             const startGameButton = document.getElementById("startGameButton");
 
@@ -119,15 +140,40 @@ Creation date: 9-10-24
 
             const radios = document.getElementsByName('ship_select');//Checks what number of ships the host chose
 
-            function newGame() {//Function runs when new game button is selected
-              newGameArea.style.display = "block";
+              function new1PGame() {//Function runs when 1P game button is selected
+                new1PGameArea.style.display = "block";
+                new2PGameArea.style.display = "none";
+                joinGameArea.style.display = "none";
+                errorFooterArea.style.display = "none";
+                }
+
+            function new2PGame() {//Function runs when 2P game button is selected
+              new1PGameArea.style.display = "none";
+              new2PGameArea.style.display = "block";
               joinGameArea.style.display = "none";
               errorFooterArea.style.display = "none";
             }
 
-            newGameButton.addEventListener('click', () => { //Waits for new game button to be pressed to run function
-              newGame();
+            onePGameButton.addEventListener('click', () => { //Waits for 1P button to be pressed to run function
+              new1PGame();
             });
+
+            twoPGameButton.addEventListener('click', () => { //Waits for 2P button to be pressed to run function
+              new2PGame();
+            });
+
+            start1PGameButton.addEventListener('click', () => { // When the Play button is pressed after selecting number of ships for a 1P game, sends request to server to start a 1P game
+                let numberOfShips = 5; //Default ship value.
+
+                //Loops through the radio buttons to find the checked one
+                for (const radio of radios) {
+                  if (radio.checked) {
+                    numberOfShips = radio.value; //Stores the value of selected radio button for number of ships
+                    break;
+                  }
+                }
+                socket.emit('initiateSinglePlayer', numberOfShips); //Sends the number of ships selected to the server to try to create the game
+                });
 
             createPartyButton.addEventListener('click', () => { //Sends request
               let numberOfShips = 3; //Default ship value
@@ -210,4 +256,5 @@ Creation date: 9-10-24
   </script>
 
 </body>
+</html>
 


### PR DESCRIPTION
I've created the structure for initiating a 1P game from the main menu. I stopped at sending the request to the server to initiate 1P mode and AI logic. I didn't include choosing a difficulty level for the AI, but it can be easily added to the form used for choosing the number of ships for the 1P game.

You can test the functionality by looking at the terminal acting as your server. After choosing the number of ships and hitting play, it should output a message saying that single-player mode is being initiated.